### PR TITLE
fix: remove unsupported usage of updating a tab title

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
   ],
   "rules": {
     "no-console": 0,
-    "no-unused-vars": ["warn", { "vars": "all", "args": "all" } ],
+    "no-unused-vars": ["warn", { "vars": "all", "args": "after-used" } ],
     "no-undef": ["warn"],
     "no-proto": ["error"],
     "prefer-arrow-callback": ["warn"],

--- a/background.js
+++ b/background.js
@@ -1,6 +1,4 @@
 "use strict";
-const SNOWFLAKE = "\u2744 ️";
-
 
 browser.menus.create({
   id: "discard",
@@ -9,10 +7,6 @@ browser.menus.create({
   contexts: ["tab"]
 });
 
-// eslint fails to realize that the param of an arrow function cant be blank/undefined, so ignore warning below
-// eslint-disable-next-line no-unused-vars
 browser.menus.onClicked.addListener((info, tab) => {
    browser.tabs.discard(tab.id);
-   browser.tabs.update(tab.id, { title: SNOWFLAKE + tab.title });
-
 });

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.1",
   "description": "Adds Discard action to tab right-click",
   "main": "background.js",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "eslint": "^4.10.0"
   },


### PR DESCRIPTION
From how I understand it, the tabs api only allows readonly access to a tabs title.
https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/tabs/update lists all possible options that an addon can write to. 
`title` is not in that list so it can't be set.

This PR removes the title update.
I've also updated the eslint config so it doesn't have to be disabled for unused function arguments.
(The package.json change was done automatically after running `npm i`)

fixes #5