### PR TITLE
Prepend snowflake to title upon tab discard

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -10,5 +10,9 @@
   "menuItemDiscard": {
     "message": "Discard Tab",
     "description": "Title of context menu item that discard the right-clicked tab."
+  },
+  "toggleSnowflakePref": {
+    "message": "Prepend snowflake to discarded tabs (requires extra permission). ",
+    "description": "Label of checkbox to toggle the setting that controls whether a snowflake is prepended to tab titles."
   }
 }

--- a/background.js
+++ b/background.js
@@ -1,4 +1,19 @@
 "use strict";
+const CODE_SHOW_SNOWFLAKE = "(" + function() {
+  const SNOWFLAKE = "\u2744 ️";
+  if (!document.title.startsWith(SNOWFLAKE)) {
+    document.title = SNOWFLAKE + document.title;
+    // Eventually restore the title, in case tabs.discard() does not
+    // work. For instance, if a "beforeunload" event exists.
+    setTimeout(() => {
+      if (document.title.startsWith(SNOWFLAKE)) {
+        document.title = document.title.replace(SNOWFLAKE, "");
+      }
+    }, 500);
+  }
+} + ")();";
+
+var prependSnowflake = false;
 
 browser.menus.create({
   id: "discard",
@@ -7,6 +22,30 @@ browser.menus.create({
   contexts: ["tab"]
 });
 
-browser.menus.onClicked.addListener((info, tab) => {
-   browser.tabs.discard(tab.id);
+browser.menus.onClicked.addListener(async (info, tab) => {
+  if (tab.discarded) {
+    return;
+  }
+  if (prependSnowflake) {
+    // Try to prepend a snowflake before the title,
+    // before discarding the tab.
+    try {
+      await browser.tabs.executeScript(tab.id, {
+        runAt: "document_start",
+        code: CODE_SHOW_SNOWFLAKE,
+      });
+    } catch (e) {
+      // This can happen if the tab is a privileged page, e.g. about:addons.
+    }
+  }
+  browser.tabs.discard(tab.id);
+});
+
+browser.storage.onChanged.addListener((changes) => {
+  if (changes.prependSnowflake) {
+    prependSnowflake = changes.prependSnowflake.newValue;
+  }
+});
+browser.storage.local.get("prependSnowflake", (items) => {
+  prependSnowflake = !!items.prependSnowflake;
 });

--- a/manifest.json
+++ b/manifest.json
@@ -15,9 +15,18 @@
     }
   },
   "permissions": [
+    "storage",
     "tabs",
     "menus"
   ],
+  "optional_permissions": [
+    "<all_urls>"
+  ],
+  "options_ui": {
+    "browser_style": true,
+    "open_in_tab": true,
+    "page": "options.html"
+  },
 
   "background": {
     "scripts": ["background.js"]

--- a/options.html
+++ b/options.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+<label>
+  <input type="checkbox" id="prefPrependSnowflake">
+  <!-- options.js will replace the label with i18n ID toggleSnowflakePref. -->
+  <span id="i18n-toggleSnowflakePref">Prepend snowflake to discarded tabs (requires extra permission).</span>
+</label>
+<script src="options.js"></script>
+</body>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var permissions = { origins: ["<all_urls>"] };
+var prefPrependSnowflake = document.getElementById("prefPrependSnowflake");
+prefPrependSnowflake.onchange = async () => {
+  if (prefPrependSnowflake.checked) {
+    prefPrependSnowflake.disabled = true;
+    // Note: permissions.request only works when this page is shown in a tab,
+    // i.e. when options_ui.open_in_tab=true in manifest.json.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1382953
+    prefPrependSnowflake.checked = await browser.permissions.request(permissions);
+    prefPrependSnowflake.disabled = false;
+  } else {
+    browser.permissions.remove(permissions);
+  }
+  browser.storage.local.set({
+    prependSnowflake: prefPrependSnowflake.checked,
+  });
+};
+
+document.getElementById("i18n-toggleSnowflakePref").textContent =
+  browser.i18n.getMessage("toggleSnowflakePref");
+
+browser.storage.onChanged.addListener((changes) => {
+  if (changes.prependSnowflake) {
+    prefPrependSnowflake.checked = changes.prependSnowflake.newValue;
+  }
+});
+browser.storage.local.get("prependSnowflake", (items) => {
+  prefPrependSnowflake.checked = !!items.prependSnowflake;
+});


### PR DESCRIPTION
This PR restores the feature that you intended to have: a snowflake in the tab title.

Previously, you tried to update the title via `tabs.update`. That is not possible, because the tabs.update API does not support a "title" key (#5), so it was removed (#6).

This PR does the following:

- Add logic to prepend a snowflake to the tab title before discarding it.
- Add options page to enable the snowflake (with an optional permission prompt)
- Explicitly add the extension ID to manifest.json (found by visitting about:support after installing the add-on from AMO), so that the extension storage is persisted during development.

An intentional side effect of the implementation is that a snowflake briefly appears and then disappears if you attempt to discard the currently selected tab. The current tab cannot be discarded by design, so this piece of UI feedback shows that something has happened in response to the user's request to discard the tab.