### PR TITLE
fix: Remove open_in_tab requirement

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,6 @@
   ],
   "options_ui": {
     "browser_style": true,
-    "open_in_tab": true,
     "page": "options.html"
   },
 

--- a/options.js
+++ b/options.js
@@ -5,9 +5,6 @@ var prefPrependSnowflake = document.getElementById("prefPrependSnowflake");
 prefPrependSnowflake.onchange = async () => {
   if (prefPrependSnowflake.checked) {
     prefPrependSnowflake.disabled = true;
-    // Note: permissions.request only works when this page is shown in a tab,
-    // i.e. when options_ui.open_in_tab=true in manifest.json.
-    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1382953
     prefPrependSnowflake.checked = await browser.permissions.request(permissions);
     prefPrependSnowflake.disabled = false;
   } else {


### PR DESCRIPTION
This requires Firefox 60, but I did not bump the `strict_min_version` because the snowflake icon is an optional feature.

Fixes #8