### PR TITLE
fix: Avoid <all_urls> permission if possible

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,7 +12,7 @@
     "description": "Title of context menu item that discard the right-clicked tab."
   },
   "toggleSnowflakePref": {
-    "message": "Prepend snowflake to discarded tabs (requires extra permission). ",
+    "message": "Prepend snowflake to discarded tabs.",
     "description": "Label of checkbox to toggle the setting that controls whether a snowflake is prepended to tab titles."
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
     }
   },
   "permissions": [
+    "activeTab",
     "storage",
     "tabs",
     "menus"

--- a/options.html
+++ b/options.html
@@ -6,7 +6,7 @@
 <label>
   <input type="checkbox" id="prefPrependSnowflake">
   <!-- options.js will replace the label with i18n ID toggleSnowflakePref. -->
-  <span id="i18n-toggleSnowflakePref">Prepend snowflake to discarded tabs (requires extra permission).</span>
+  <span id="i18n-toggleSnowflakePref">Prepend snowflake to discarded tabs.</span>
 </label>
 <script src="options.js"></script>
 </body>

--- a/options.js
+++ b/options.js
@@ -1,9 +1,22 @@
 "use strict";
 
+function requiresPermission() {
+  // As of Firefox 63, the "activeTab" unlocks access to the tab that was
+  // clicked ( https://bugzilla.mozilla.org/show_bug.cgi?id=1446956 ).
+  // Support for this functionality cannot easily be detected, so indirectly
+  // infer support for this feature via a different change in the same release:
+  // https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/63#Menus
+
+  // If we ever stop supporting Firefox 62 and earlier (including ESR 60), then
+  // the "<all_urls>" optional permission can be removed from manifest.json,
+  // together with the uses of the browser.permissions API in this file.
+  return !browser.menus.getTargetElement;
+}
+
 var permissions = { origins: ["<all_urls>"] };
 var prefPrependSnowflake = document.getElementById("prefPrependSnowflake");
 prefPrependSnowflake.onchange = async () => {
-  if (prefPrependSnowflake.checked) {
+  if (prefPrependSnowflake.checked && requiresPermission()) {
     prefPrependSnowflake.disabled = true;
     // Note: permissions.request only works when this page is shown in a tab,
     // i.e. when options_ui.open_in_tab=true in manifest.json.


### PR DESCRIPTION
This is a follow-up to https://github.com/freddyb/webext-discard-tab/pull/7#issuecomment-374232978 .