### PR TITLE
Discard multiselected tabs also

### DIFF
--- a/background.js
+++ b/background.js
@@ -49,7 +49,7 @@ browser.menus.onClicked.addListener(async (info, tab) => {
       code: CODE_SHOW_SNOWFLAKE,
     }).catch(error => {
       errors.push(error);
-      console.error(error);
+      console.error(error, `tab id: ${id}`);
     })));
     if (errors.length > 0) {
       // This can happen if the tab is a privileged page, e.g. about:addons.

--- a/background.js
+++ b/background.js
@@ -45,8 +45,8 @@ browser.menus.onClicked.addListener(async (info, tab) => {
     // before discarding the tab.
     const errors = [];
     await Promise.all(ids.map(id => browser.tabs.executeScript(id, {
-        runAt: "document_start",
-        code: CODE_SHOW_SNOWFLAKE,
+      runAt: "document_start",
+      code: CODE_SHOW_SNOWFLAKE,
     }).catch(error => {
       errors.push(error);
       console.error(error);

--- a/background.js
+++ b/background.js
@@ -43,12 +43,15 @@ browser.menus.onClicked.addListener(async (info, tab) => {
   if (prependSnowflake) {
     // Try to prepend a snowflake before the title,
     // before discarding the tab.
-    try {
-      await Promise.all(ids.map(id => browser.tabs.executeScript(id, {
+    const errors = [];
+    await Promise.all(ids.map(id => browser.tabs.executeScript(id, {
         runAt: "document_start",
         code: CODE_SHOW_SNOWFLAKE,
-      })));
-    } catch (e) {
+    }).catch(error => {
+      errors.push(error);
+      console.error(error);
+    })));
+    if (errors.length > 0) {
       // This can happen if the tab is a privileged page, e.g. about:addons.
     }
   }

--- a/background.js
+++ b/background.js
@@ -25,8 +25,8 @@ browser.menus.create({
 async function getHighlightedTabs(tab) {
   if (tab.highlighted) {
     return browser.tabs.query({
-      windowId:    tab.windowId,
-      highlighted: true
+      windowId: tab.windowId,
+      highlighted: true,
     });
   }
   else {

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
   "applications": {
     "gecko": {
       "id": "{44173eb0-7ea4-5959-8bde-d85c2f8b4e25}",
-      "strict_min_version": "58.0a1"
+      "strict_min_version": "64"
     }
   },
   "permissions": [


### PR DESCRIPTION
# Motivation

Firefox 64 and later supports multiselection of tabs. You can highlight multiple tabs via Ctrl-click or Shift-click on the tab bar, then "Reload Tab" and other commands in the tab context menu work for all highlighted tabs.

On the other hand, this addon currently doesn't match to the behavior described above. "Discard Tab" command always affects only to the single context tab. This PR aims to solve this problem. How about this improvement?

# Implementation

We can collect multiselected tabs via `tabs.query({ highlighted: true })`. This PR inserts a logic to do that if the context tab is highlighted, and it collects `htabs` (to be discarded tabs) from each highlighted tabs.

# Concerns

* Only Firefox 64 and later supports querying of highlighted tabs, so this change requires updating strict minimum version to 64.
* When multiple tabs become discarded, the `CODE_SHOW_SNOWFLAKE` need to be executed in background non-active tabs. This requires that `<all_urls>` optional permission, so `requiresPermission()` in `options.js` looks to need to return true on Firefox 64 and later.